### PR TITLE
Migrated to Lume 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
-<!-- deno-fmt-ignore-file -->
-
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
@@ -11,18 +10,26 @@ project adheres to [Semantic Versioning](http://semver.org/).
 Migrated to Lume 3
 
 ### Added
-- [minifyHTML](https://lume.land/plugins/minify_html/) plugin for optimization and a better [DebugBar](https://lume.land/docs/core/debugbar/) experience on the dev server
-- [checkUrls](https://lume.land/plugins/check_urls/) plugin because [nobody likes dead links](https://lume.land/blog/posts/lume-2-4-0-maruja-mallo/#new-plugin%3A-check_urls)
-- `site.add("style.css")` to make LightningCSS [load file explicitly](https://lume.land/blog/posts/lume-3/#plugins-no-longer-load-files-automatically)
+
+- `deno task update-deps` to use [nudd](https://github.com/oscarotero/nudd) for
+  updating dependencies
+- `site.add("style.css")` to make LightningCSS
+  [load file explicitly](https://lume.land/blog/posts/lume-3/#plugins-no-longer-load-files-automatically)
 - `lume/jsx-runtime` for [SSX](https://github.com/oscarotero/ssx) support
-- `lume/lint.ts` [plugin-order](https://lume.land/docs/advanced/migrate-to-lume3/#plugins-order) hinting
+- `lume/lint.ts`
+  [plugin-order](https://lume.land/docs/advanced/migrate-to-lume3/#plugins-order)
+  hinting
 
 ### Changed
+
 - Bumped Lume to [v3.0.2](https://github.com/lumeland/lume/releases/tag/v3.0.2)
-- Bumped lume/cms to [v0.11.5](https://github.com/lumeland/cms/releases/tag/v0.11.5)
-- Bumped changelog to [v2.6.2](https://github.com/oscarotero/keep-a-changelog/releases/tag/v2.6.2)
+- Bumped lume/cms to
+  [v0.11.5](https://github.com/lumeland/cms/releases/tag/v0.11.5)
+- Bumped changelog to
+  [v2.6.2](https://github.com/oscarotero/keep-a-changelog/releases/tag/v2.6.2)
 
 ## [0.1.0] - 2025-04-18
+
 First version
 
 [0.1.0]: https://github.com/lumeland/theme-boilerplate/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.1.0 - Unreleased
+## [0.2.0] - 2025-06-11
+
+Migrated to Lume 3
+
+### Added
+- [minifyHTML](https://lume.land/plugins/minify_html/) plugin for optimization and a better [DebugBar](https://lume.land/docs/core/debugbar/) experience on the dev server
+- [checkUrls](https://lume.land/plugins/check_urls/) plugin because [nobody likes dead links](https://lume.land/blog/posts/lume-2-4-0-maruja-mallo/#new-plugin%3A-check_urls)
+- `site.add("style.css")` to make LightningCSS [load file explicitly](https://lume.land/blog/posts/lume-3/#plugins-no-longer-load-files-automatically)
+- `lume/jsx-runtime` for [SSX](https://github.com/oscarotero/ssx) support
+- `lume/lint.ts` [plugin-order](https://lume.land/docs/advanced/migrate-to-lume3/#plugins-order) hinting
+
+### Changed
+- Bumped Lume to [v3.0.2](https://github.com/lumeland/lume/releases/tag/v3.0.2)
+- Bumped lume/cms to [v0.11.5](https://github.com/lumeland/cms/releases/tag/v0.11.5)
+- Bumped changelog to [v2.6.2](https://github.com/oscarotero/keep-a-changelog/releases/tag/v2.6.2)
+
+[0.2.0]: https://github.com/lumeland/theme-boilerplate/releases/tag/v0.2.0
+
+## [0.1.0] - 2025-04-18
 First version
+
+[0.1.0]: https://github.com/lumeland/theme-boilerplate/releases/tag/v0.1.0

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.5.3/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.3/"
+    "lume/": "https://deno.land/x/lume@v3.0.2/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "lock": false,
   "tasks": {
@@ -11,18 +12,17 @@
     "cms": "deno task lume cms",
     "changelog": {
       "description": "Run the changelog utility to format the CHANGELOG.md file",
-      "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.5.3/bin.ts"
+      "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.6.2/bin.ts"
     }
   },
   "compilerOptions": {
-    "types": [
-      "lume/types.ts"
-    ]
+    "types": ["lume/types.ts"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "lume"
   },
-  "exclude": [
-    "./_site"
-  ],
-  "unstable": [
-    "temporal"
-  ]
+  "exclude": ["./_site"],
+  "unstable": ["temporal"],
+  "lint": {
+    "plugins": ["https://deno.land/x/lume@v3.0.2/lint.ts"]
+  }
 }

--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     "build": "deno task lume",
     "serve": "deno task lume -s",
     "cms": "deno task lume cms",
+    "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update plugins.ts deno.json",
     "changelog": {
       "description": "Run the changelog utility to format the CHANGELOG.md file",
       "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.6.2/bin.ts"

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,6 +1,4 @@
 import lightningcss from "lume/plugins/lightningcss.ts";
-import minifyHTML from "lume/plugins/minify_html.ts";
-import checkUrls from "lume/plugins/check_urls.ts";
 import basePath from "lume/plugins/base_path.ts";
 import metas from "lume/plugins/metas.ts";
 import { Options as SitemapOptions, sitemap } from "lume/plugins/sitemap.ts";
@@ -27,8 +25,6 @@ export default function (userOptions?: Options) {
   return (site: Lume.Site) => {
     site
       .use(lightningcss())
-      .use(minifyHTML())
-      .use(checkUrls())
       .use(basePath())
       .use(metas())
       .use(sitemap(options.sitemap))

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,4 +1,6 @@
 import lightningcss from "lume/plugins/lightningcss.ts";
+import minifyHTML from "lume/plugins/minify_html.ts";
+import checkUrls from "lume/plugins/check_urls.ts";
 import basePath from "lume/plugins/base_path.ts";
 import metas from "lume/plugins/metas.ts";
 import { Options as SitemapOptions, sitemap } from "lume/plugins/sitemap.ts";
@@ -23,11 +25,15 @@ export default function (userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Lume.Site) => {
-    site.use(lightningcss())
+    site
+      .use(lightningcss())
+      .use(minifyHTML())
+      .use(checkUrls())
       .use(basePath())
       .use(metas())
       .use(sitemap(options.sitemap))
       .use(favicon(options.favicon))
-      .copy("uploads");
+      .add("uploads")
+      .add("style.css");
   };
 }

--- a/test/deno.json
+++ b/test/deno.json
@@ -1,8 +1,9 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.5.3/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.3/",
-    "theme/": "../"
+    "lume/": "https://deno.land/x/lume@v3.0.2/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
+    "theme/": "../",
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "lock": false,
   "tasks": {
@@ -12,18 +13,17 @@
     "cms": "deno task lume cms",
     "changelog": {
       "description": "Run the changelog utility to format the CHANGELOG.md file",
-      "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.5.3/bin.ts"
+      "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.6.2/bin.ts"
     }
   },
   "compilerOptions": {
-    "types": [
-      "lume/types.ts"
-    ]
+    "types": ["lume/types.ts"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "lume"
   },
-  "exclude": [
-    "./_site"
-  ],
-  "unstable": [
-    "temporal"
-  ]
+  "exclude": ["./_site"],
+  "unstable": ["temporal"],
+  "lint": {
+    "plugins": ["https://deno.land/x/lume@v3.0.2/lint.ts"]
+  }
 }

--- a/test/deno.json
+++ b/test/deno.json
@@ -11,6 +11,7 @@
     "build": "deno task lume",
     "serve": "deno task lume -s",
     "cms": "deno task lume cms",
+    "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update plugins.ts deno.json",
     "changelog": {
       "description": "Run the changelog utility to format the CHANGELOG.md file",
       "command": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.6.2/bin.ts"


### PR DESCRIPTION
Migrated to Lume 3

### Added
- [minifyHTML](https://lume.land/plugins/minify_html/) plugin for optimization and a better [DebugBar](https://lume.land/docs/core/debugbar/) experience on the dev server
- [checkUrls](https://lume.land/plugins/check_urls/) plugin because [nobody likes dead links](https://lume.land/blog/posts/lume-2-4-0-maruja-mallo/#new-plugin%3A-check_urls)
- `site.add("style.css")` to make LightningCSS [load file explicitly](https://lume.land/blog/posts/lume-3/#plugins-no-longer-load-files-automatically)
- `lume/jsx-runtime` for [SSX](https://github.com/oscarotero/ssx) support
- `lume/lint.ts` [plugin-order](https://lume.land/docs/advanced/migrate-to-lume3/#plugins-order) hinting

### Changed
- Bumped Lume to [v3.0.2](https://github.com/lumeland/lume/releases/tag/v3.0.2)
- Bumped lume/cms to [v0.11.5](https://github.com/lumeland/cms/releases/tag/v0.11.5)
- Bumped changelog to [v2.6.2](https://github.com/oscarotero/keep-a-changelog/releases/tag/v2.6.2)

Initially I wanted to add the [purgecss](https://lume.land/plugins/purgecss/) plugin. But I just noticed that PurgeCSS by default only processes `[ ".html", ".js" ]`, even though the name makes it sound like this plugin is about `.css` files. Plus, it's not on [lume.land](https://lume.land/) or in any of the themes, so it's unnecessary in this boilerplate.